### PR TITLE
feat: add block comments

### DIFF
--- a/languages/mdx/config.toml
+++ b/languages/mdx/config.toml
@@ -9,9 +9,9 @@ brackets = [
     { start = "<", end = ">", close = false, newline = true, not_in = ["comment", "string"] },
     { start = "</", end = ">", close = true, newline = true, not_in = ["comment", "string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
-    { start = "`", end = "`", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] },
 ]
+block_comment = { start = "{/* ", prefix = "", end = "*/}", tab_size = 0 }
 
 [jsx_tag_auto_close]
 open_tag_node_name = "jsx_opening_element"


### PR DESCRIPTION
Addresses https://github.com/srazzak/zed-mdx/issues/10

Users can now comment lines and blocks with `gcc` or `Ctrl+/`