### PR TITLE
windows fix

### DIFF
--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -4,7 +4,11 @@ use zed_extension_api::serde_json::json;
 use zed_extension_api::settings::LspSettings;
 use zed_extension_api::{self as zed, Result, serde_json};
 
+#[cfg(windows)]
+const SERVER_PATH: &str = r"node_modules\@mdx-js\language-server\lib\index.js";
+#[cfg(not(windows))]
 const SERVER_PATH: &str = "node_modules/@mdx-js/language-server/lib/index.js";
+
 const PACKAGE_NAME: &str = "@mdx-js/language-server";
 
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";


### PR DESCRIPTION
Description
close #14 
Currently, the extension hardcodes the SERVER_PATH using POSIX-style forward slashes (/). This causes the language server to fail to start on Windows because fs::metadata and some Node.js execution contexts cannot correctly resolve the path to the language server entry point.

This PR introduces conditional compilation using #[cfg(windows)] to ensure the correct path separators and raw string literals are used on Windows, while maintaining existing behavior for macOS and Linux.

Changes
Added #[cfg(windows)] constant for SERVER_PATH using backslashes and raw string syntax (r"...").

Kept POSIX-style path for non-Windows platforms.

Ensures server_exists() check passes correctly on Windows environments.

Testing
[x] Verified on Windows: The MDX language server now starts correctly and provides linting/completion.
[ ] Linux/macOS: Not tested (no access to these environments), but the logic for these platforms remains unchanged as it is wrapped in #[cfg(not(windows))].